### PR TITLE
Use logging API instead backed as a dependency to fix #184. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ junitPlatform {
 }
 
 dependencies {
-    compile("org.slf4j:slf4j-log4j12:1.7.22")
+    compile("org.slf4j:slf4j-api:1.7.24")
     compile("org.apache.commons:commons-lang3:3.4")
     compile("org.apache.commons:commons-collections4:4.1")
     compile("com.googlecode.combinatoricslib:combinatoricslib:2.1")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 08 18:23:02 CET 2017
+#Wed Mar 08 20:22:19 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip


### PR DESCRIPTION
Also upgraded gradle wrapper to use distribution with DSL documentation (Idea tip).