### PR TITLE
fix pojo tests with final attributes

### DIFF
--- a/src/main/java/pl/pojo/tester/internal/tester/SetterTester.java
+++ b/src/main/java/pl/pojo/tester/internal/tester/SetterTester.java
@@ -11,6 +11,8 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static pl.pojo.tester.internal.utils.FieldUtils.isFinal;
+
 public class SetterTester extends AbstractTester {
 
     public SetterTester() {
@@ -46,6 +48,7 @@ public class SetterTester extends AbstractTester {
     private List<SetterAndFieldPair> findSetterAndGetterPairsForFields(final Class<?> testedClass,
                                                                        final List<Field> fields) {
         return fields.stream()
+                     .filter(field -> ! isFinal(field))
                      .map(fieldName -> findSetterAndGetterPairForField(testedClass, fieldName))
                      .collect(Collectors.toList());
     }

--- a/src/test/java/pl/pojo/tester/internal/tester/SetterTesterTest.java
+++ b/src/test/java/pl/pojo/tester/internal/tester/SetterTesterTest.java
@@ -96,7 +96,7 @@ class SetterTesterTest {
         private int a;
         private int b;
         private int c;
-        private int d;
+        private final int d = 0;
 
     }
 


### PR DESCRIPTION
This PR fixes pojo tests with final fields. A setter should not be expected on a final field.