### PR TITLE
[Feature] custom instantiators

### DIFF
--- a/src/main/java/pl/pojo/tester/internal/instantiator/AbstractMultiConstructorInstantiator.java
+++ b/src/main/java/pl/pojo/tester/internal/instantiator/AbstractMultiConstructorInstantiator.java
@@ -97,7 +97,7 @@ abstract class AbstractMultiConstructorInstantiator extends AbstractObjectInstan
                      .toArray(Object[]::new);
     }
 
-    private Object createObjectFromConstructor(final Constructor<?> constructor) {
+    protected Object createObjectFromConstructor(final Constructor<?> constructor) {
         makeAccessible(constructor);
         if (constructor.getParameterCount() == 0) {
             return createObjectFromNoArgsConstructor(constructor);

--- a/src/main/java/pl/pojo/tester/internal/instantiator/BestConstructorInstantiator.java
+++ b/src/main/java/pl/pojo/tester/internal/instantiator/BestConstructorInstantiator.java
@@ -9,12 +9,12 @@ import pl.pojo.tester.api.ConstructorParameters;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-class BestConstructorInstantiator extends AbstractMultiConstructorInstantiator {
+public class BestConstructorInstantiator extends AbstractMultiConstructorInstantiator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BestConstructorInstantiator.class);
 
-    BestConstructorInstantiator(final Class<?> clazz,
-                                final MultiValuedMap<Class<?>, ConstructorParameters> constructorParameters) {
+    public BestConstructorInstantiator(final Class<?> clazz,
+                                       final MultiValuedMap<Class<?>, ConstructorParameters> constructorParameters) {
         super(clazz, constructorParameters);
     }
 

--- a/src/main/java/pl/pojo/tester/internal/instantiator/Instantiable.java
+++ b/src/main/java/pl/pojo/tester/internal/instantiator/Instantiable.java
@@ -7,24 +7,11 @@ import pl.pojo.tester.api.ConstructorParameters;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
+import static pl.pojo.tester.internal.instantiator.Instantiator.INSTANTIATORS;
+
 public final class Instantiable {
-
-    private static final List<Class<? extends AbstractObjectInstantiator>> INSTANTIATORS;
-
-    static {
-        INSTANTIATORS = new LinkedList<>();
-        INSTANTIATORS.add(UserDefinedConstructorInstantiator.class);
-        INSTANTIATORS.add(JavaTypeInstantiator.class);
-        INSTANTIATORS.add(CollectionInstantiator.class);
-        INSTANTIATORS.add(DefaultConstructorInstantiator.class);
-        INSTANTIATORS.add(EnumInstantiator.class);
-        INSTANTIATORS.add(ArrayInstantiator.class);
-        INSTANTIATORS.add(ProxyInstantiator.class);
-        INSTANTIATORS.add(BestConstructorInstantiator.class);
-    }
 
     private Instantiable() {
     }
@@ -41,8 +28,8 @@ public final class Instantiable {
                                                final MultiValuedMap<Class<?>, ConstructorParameters> constructorParameters) {
         return instantiateInstantiators(clazz, constructorParameters).stream()
                                                                      .filter(AbstractObjectInstantiator::canInstantiate)
-                                                                     .findAny()
-                                                                     .get();
+                                                                     .findFirst()
+                                                                     .orElseThrow(() -> new RuntimeException("No instantiator found for class " + clazz.getName()));
     }
 
     private static List<AbstractObjectInstantiator> instantiateInstantiators(final Class<?> clazz,

--- a/src/main/java/pl/pojo/tester/internal/instantiator/Instantiator.java
+++ b/src/main/java/pl/pojo/tester/internal/instantiator/Instantiator.java
@@ -1,0 +1,31 @@
+package pl.pojo.tester.internal.instantiator;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public final class Instantiator {
+
+    public static final Instantiator INSTANCE = new Instantiator();
+
+    static final List<Class<? extends AbstractObjectInstantiator>> INSTANTIATORS;
+    private final static int INTERNAL_INSTANTIATORS_NUMBER;
+
+    static {
+        INSTANTIATORS = new LinkedList<>();
+        INSTANTIATORS.add(UserDefinedConstructorInstantiator.class);
+        INSTANTIATORS.add(JavaTypeInstantiator.class);
+        INSTANTIATORS.add(CollectionInstantiator.class);
+        INSTANTIATORS.add(DefaultConstructorInstantiator.class);
+        INSTANTIATORS.add(EnumInstantiator.class);
+        INSTANTIATORS.add(ArrayInstantiator.class);
+        INSTANTIATORS.add(ProxyInstantiator.class);
+        INSTANTIATORS.add(BestConstructorInstantiator.class);
+
+        INTERNAL_INSTANTIATORS_NUMBER = INSTANTIATORS.size();
+    }
+
+    public Instantiator attach(final Class<? extends AbstractObjectInstantiator> clazz) {
+        INSTANTIATORS.add(INSTANTIATORS.size() - INTERNAL_INSTANTIATORS_NUMBER, clazz);
+        return this;
+    }
+}

--- a/src/main/java/pl/pojo/tester/internal/instantiator/ObjectInstantiationException.java
+++ b/src/main/java/pl/pojo/tester/internal/instantiator/ObjectInstantiationException.java
@@ -3,7 +3,7 @@ package pl.pojo.tester.internal.instantiator;
 
 import java.util.Arrays;
 
-class ObjectInstantiationException extends RuntimeException {
+public class ObjectInstantiationException extends RuntimeException {
 
     ObjectInstantiationException(final Class<?> clazz, final String message, final Throwable cause) {
         super(createMessage(clazz) + " " + message, cause);

--- a/src/main/java/pl/pojo/tester/internal/instantiator/UserObjectInstantiator.java
+++ b/src/main/java/pl/pojo/tester/internal/instantiator/UserObjectInstantiator.java
@@ -1,0 +1,28 @@
+package pl.pojo.tester.internal.instantiator;
+
+
+import org.apache.commons.collections4.MultiValuedMap;
+import pl.pojo.tester.api.ConstructorParameters;
+
+import java.util.Optional;
+
+
+public abstract class UserObjectInstantiator extends AbstractObjectInstantiator {
+
+    public UserObjectInstantiator(final Class<?> clazz,
+                           final MultiValuedMap<Class<?>, ConstructorParameters> constructorParameters) {
+        super(clazz, constructorParameters);
+    }
+
+    @Override
+    public Object instantiate() {
+        return tryToInstantiate()
+                .orElseThrow(this::createObjectInstantiationException);
+    }
+
+    public abstract Optional<Object> tryToInstantiate();
+
+    private ObjectInstantiationException createObjectInstantiationException() {
+        return new ObjectInstantiationException(clazz, "There is no declared object for class " + clazz.getName());
+    }
+}

--- a/src/test/java/pl/pojo/tester/internal/instantiator/InstantiatorTest.java
+++ b/src/test/java/pl/pojo/tester/internal/instantiator/InstantiatorTest.java
@@ -1,0 +1,73 @@
+package pl.pojo.tester.internal.instantiator;
+
+import org.apache.commons.collections4.MultiValuedMap;
+import org.junit.jupiter.api.Test;
+import pl.pojo.tester.api.ConstructorParameters;
+
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstantiatorTest {
+
+    @Test
+    public void should_attach_instantiators() {
+        Instantiator.INSTANCE
+                .attach(CustomInstantiator.class)
+                .attach(CustomInstantiator2.class);
+
+        assertThat(Instantiator.INSTANTIATORS)
+                .containsExactly(
+                        CustomInstantiator.class,
+                        CustomInstantiator2.class,
+                        UserDefinedConstructorInstantiator.class,
+                        JavaTypeInstantiator.class,
+                        CollectionInstantiator.class,
+                        DefaultConstructorInstantiator.class,
+                        EnumInstantiator.class,
+                        ArrayInstantiator.class,
+                        ProxyInstantiator.class,
+                        BestConstructorInstantiator.class
+                );
+    }
+
+    private static class CustomInstantiator extends UserObjectInstantiator {
+
+        CustomInstantiator(final Class<?> clazz,
+                           final MultiValuedMap<Class<?>, ConstructorParameters> constructorParameters) {
+            super(clazz, constructorParameters);
+
+        }
+
+        @Override
+        public Optional<Object> tryToInstantiate() {
+            return empty();
+        }
+
+        @Override
+        public boolean canInstantiate() {
+            return false;
+        }
+    }
+
+    private static class CustomInstantiator2 extends UserObjectInstantiator {
+
+        CustomInstantiator2(final Class<?> clazz,
+                           final MultiValuedMap<Class<?>, ConstructorParameters> constructorParameters) {
+            super(clazz, constructorParameters);
+
+        }
+
+        @Override
+        public Optional<Object> tryToInstantiate() {
+            return empty();
+        }
+
+        @Override
+        public boolean canInstantiate() {
+            return false;
+        }
+    }
+
+}

--- a/src/test/java/pl/pojo/tester/internal/instantiator/UserObjectInstantiatorTest.java
+++ b/src/test/java/pl/pojo/tester/internal/instantiator/UserObjectInstantiatorTest.java
@@ -1,0 +1,59 @@
+package pl.pojo.tester.internal.instantiator;
+
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UserObjectInstantiatorTest {
+
+    @Test
+    public void should_instantiate() {
+        // Given
+        UserObjectInstantiator instantiator = new UserObjectInstantiator(String.class, new HashSetValuedHashMap<>()) {
+            @Override
+            public Optional<Object> tryToInstantiate() {
+                return Optional.of("a String instance");
+            }
+
+            @Override
+            public boolean canInstantiate() {
+                return true;
+            }
+        };
+
+        // When
+        Object object = instantiator.instantiate();
+
+        // Then
+        assertThat(object).isEqualTo("a String instance");
+    }
+
+    @Test
+    public void should_not_instantiate_and_throw_exception() {
+        // Given
+        UserObjectInstantiator instantiator = new UserObjectInstantiator(String.class, new HashSetValuedHashMap<>()) {
+            @Override
+            public Optional<Object> tryToInstantiate() {
+                return empty();
+            }
+
+            @Override
+            public boolean canInstantiate() {
+                return true;
+            }
+        };
+
+        // When
+        Executable executable = instantiator::instantiate;
+
+        // Then
+        assertThrows(ObjectInstantiationException.class, executable);
+    }
+
+}


### PR DESCRIPTION
The idea of this feature is to provide a mechanism for users to define custom instantiators like it exists for custom field value changers. It follows the same idea to let user extends pojo-tester mechanism.

It existes already a mechanism that let the user to select the choosen constructor (explanations [here](https://www.pojo.pl/writing-tests/#choose-constructor)) but it is not efficient when the pojo use provided types from external libraries.

Here are the steps to add pojo tester support for an external librairy types (for example [vavr](https://www.vavr.io)) in an external project :

1. Step 1 : define instantiator for custom types ([vavr types](https://github.com/galeries-lafayette/lib-unit-test/blob/master/pojo-tester-extensions/vavr/src/main/java/com/ggl/pojo/tester/vavr/instantiator/VavrTypesInstantiator.java) for example). You have to inherits the **UserObjectInstantiator** class
2. Step 2 : use custom instantiator : 
`Instantiator.INSTANCE.attach(VavrTypesInstantiator.class);`

Now we can use pojo tester with an object using vavr types, for example : 
```java
class User {
    private int id;
    private Option<String> email;  // Option is a Vavr type
}
```

Detailed example [here](https://github.com/galeries-lafayette/lib-unit-test/blob/master/pojo-tester-extensions/vavr/src/test/java/com/ggl/pojo/tester/vavr/config/VavrConfigTest.java).