### PR TITLE
fix equals/hashcode on class with inner class

### DIFF
--- a/src/main/java/pl/pojo/tester/internal/field/AbstractFieldValueChanger.java
+++ b/src/main/java/pl/pojo/tester/internal/field/AbstractFieldValueChanger.java
@@ -53,7 +53,7 @@ public abstract class AbstractFieldValueChanger<T> {
                 return (T) next.increaseValue(value);
             }
             LOGGER.debug("Could not change value '{}' ot type {} by any field value changer", value, value.getClass());
-            return value;
+            return null;
         }
     }
 

--- a/src/test/java/pl/pojo/tester/internal/field/AbstractFieldValueChangerTest.java
+++ b/src/test/java/pl/pojo/tester/internal/field/AbstractFieldValueChangerTest.java
@@ -30,7 +30,7 @@ class AbstractFieldValueChangerTest {
     }
 
     @Test
-    void Should_Not_Change_If_No_Matching_Changer() {
+    void Should_Be_Null_If_No_Matching_Changer() {
         // given
         final AbstractFieldValueChanger abstractFieldValueChanger = new ImplementationForTest();
         final String expectedValue = "string";
@@ -39,7 +39,7 @@ class AbstractFieldValueChangerTest {
         final Object result = abstractFieldValueChanger.increaseValue(expectedValue);
 
         // then
-        assertThat(result).isEqualTo(expectedValue);
+        assertThat(result).isNull();
     }
 
     @Test

--- a/src/test/java/pl/pojo/tester/internal/tester/EqualsTesterTest.java
+++ b/src/test/java/pl/pojo/tester/internal/tester/EqualsTesterTest.java
@@ -34,6 +34,19 @@ class EqualsTesterTest {
     }
 
     @Test
+    void Should_Pass_All_Equals_Tests_On_Embedded_Classes() {
+        // given
+        final Class[] classesToTest = {GoodPojo_Equals_HashCode_Inner_Class.class};
+        final EqualsTester equalsTester = new EqualsTester(DefaultFieldValueChanger.INSTANCE);
+
+        // when
+        final Throwable result = catchThrowable(() -> equalsTester.testAll(classesToTest));
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
     void Should_Pass_All_Equals_Tests_Excluding_Fields() {
         // given
         final EqualsTester equalsTester = new EqualsTester();

--- a/src/test/java/pl/pojo/tester/internal/tester/GoodPojo_Equals_HashCode_Inner_Class.java
+++ b/src/test/java/pl/pojo/tester/internal/tester/GoodPojo_Equals_HashCode_Inner_Class.java
@@ -1,0 +1,15 @@
+package pl.pojo.tester.internal.tester;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GoodPojo_Equals_HashCode_Inner_Class {
+    private InternalClass internalClass;
+
+    @Data
+    public static class InternalClass {
+        String id;
+    }
+}


### PR DESCRIPTION
A proposal solution for https://github.com/sta-szek/pojo-tester/issues/240.

The problem was the builder generates an all args constructor with generated values.
When the valueChanger tried to change inner class value, because it doesn't find a corresponding valueChanger it returned the same value.

A solution is to return null, which is by construction different from the initial generated value.